### PR TITLE
Fix footnote in markdown

### DIFF
--- a/docs/smac.md
+++ b/docs/smac.md
@@ -98,7 +98,7 @@ The complete list of challenges is presented bellow. The difficulty of the game 
 
 At each timestep, agents receive local observations drawn within their field of view. This  encompasses information about the map within a circular area around each unit and with a radius equal to the _sight range_. The sight range makes the environment partially observable from the standpoint of each agent. Agents can only observe other agents if they are both alive and located within the sight range. Hence, there is no way for agents to determine whether their teammates are far away or dead.
 
-The feature vector observed by each agent contains the following attributes for both allied and enemy units within the sight range: _distance_, _relative x_, _relative y_, _health_, _shield_, and _unit\_type_.\footnote{_health_, _shield_ and _unit\_type_ of the unit the agent controls is also included in observations_. Shields serve as an additional source of protection that needs to be removed before any damage can be done to the health of units.
+The feature vector observed by each agent contains the following attributes for both allied and enemy units within the sight range: _distance_, _relative x_, _relative y_, _health_, _shield_, and _unit\_type_ <sup>[1](#myfootnote1)</sup>. Shields serve as an additional source of protection that needs to be removed before any damage can be done to the health of units.
 All Protos units have shields, which can regenerate if no new damage is dealt
 (units of the other two races do not have this attribute).
 In addition, agents have access to the last actions of allied units that are in the field of view. Lastly, agents can observe the terrain features surrounding them; particularly, the values of eight points at a fixed radius indicating height and walkability.
@@ -134,3 +134,5 @@ Furthermore, to encourage agents to explore interesting micro-strategies themsel
 To do so, we make use of new units created with the StarCraft II Editor that are exact copies of existing units with two attributes modified: _Combat: Default Acquire Level_ is set to _Passive_ (default _Offensive_) and _Behaviour: Response_ is set to _No Response_ (default _Acquire_). These fields are only modified for allied units; enemy units are unchanged.
 
 The sight and shooting range values might differ from the built-in _sight_ or _range_ attribute of some StarCraft II units. Our goal is not to master the original full StarCraft game, but rather to benchmark MARL methods for decentralised control.
+
+<a name="myfootnote1">1</a>: _health_, _shield_ and _unit\_type_ of the unit the agent controls is also included in observations


### PR DESCRIPTION
There was a LaTeX \footnote{} command around a sentence in a markdown file. I transformed that into an actual footnote. Since GitHub Markdown does not support footnotes, I used HTML.