### PR TITLE
Create method to return a visibility matrix

### DIFF
--- a/smac/env/starcraft2/starcraft2.py
+++ b/smac/env/starcraft2/starcraft2.py
@@ -1160,9 +1160,14 @@ class StarCraft2Env(MultiAgentEnv):
         return size
 
     def get_visibility_matrix(self):
-        """Returns a boolean numpy array of dimensions (n_agents, n_agents + n_enemies)
-        indicating which units are visible to each agent."""
-        arr = np.zeros((self.n_agents, self.n_agents + self.n_enemies), dtype=np.bool)
+        """Returns a boolean numpy array of dimensions 
+        (n_agents, n_agents + n_enemies) indicating which units
+        are visible to each agent.
+        """
+        arr = np.zeros(
+            (self.n_agents, self.n_agents + self.n_enemies), 
+            dtype=np.bool,
+        )
 
         for agent_id in range(self.n_agents):
             current_agent = self.get_unit_by_id(agent_id)
@@ -1177,19 +1182,23 @@ class StarCraft2Env(MultiAgentEnv):
                     e_y = e_unit.pos.y
                     dist = self.distance(x, y, e_x, e_y)
 
-                    if (dist < sight_range and e_unit.health > 0):  # visible and alive
+                    if (dist < sight_range and e_unit.health > 0):
+                        # visible and alive
                         arr[agent_id, self.n_agents + e_id] = 1
 
-                # the allies part of the matrix is filled symmetrically
-                # this may not work when units have different sight distances
-                al_ids = [al_id for al_id in range(self.n_agents) if al_id > agent_id]
+                # The matrix for allies is filled symmetrically
+                al_ids = [
+                    al_id for al_id in range(self.n_agents) 
+                    if al_id > agent_id
+                ]
                 for i, al_id in enumerate(al_ids):
                     al_unit = self.get_unit_by_id(al_id)
                     al_x = al_unit.pos.x
                     al_y = al_unit.pos.y
                     dist = self.distance(x, y, al_x, al_y)
 
-                    if (dist < sight_range and al_unit.health > 0):  # visible and alive
+                    if (dist < sight_range and al_unit.health > 0):  
+                        # visible and alive
                         arr[agent_id, al_id] = arr[al_id, agent_id] = 1
 
         return arr

--- a/smac/examples/random_agents.py
+++ b/smac/examples/random_agents.py
@@ -24,6 +24,8 @@ def main():
             obs = env.get_obs()
             state = env.get_state()
 
+            arr = env.get_visibility_matrix()
+
             actions = []
             for agent_id in range(n_agents):
                 avail_actions = env.get_avail_agent_actions(agent_id)

--- a/smac/examples/random_agents.py
+++ b/smac/examples/random_agents.py
@@ -24,8 +24,6 @@ def main():
             obs = env.get_obs()
             state = env.get_state()
 
-            arr = env.get_visibility_matrix()
-
             actions = []
             for agent_id in range(n_agents):
                 avail_actions = env.get_avail_agent_actions(agent_id)


### PR DESCRIPTION
The matrix dimensions are `n_agents X (n_agents * n_enemies)`. `arr[i, j]` is `True` if agent `i` sees unit `j`, `False` otherwise. In the longest dimension, agents come first, then enemies. I make use of the fact that all units have the same sight range and take `O(n_agents / 2 + n_agents * n_enemies)` operations to fill the matrix, since the agent/agent part is symmetrical.

I have added a call to the new method in the example agent in order to test it but, on second thought, I don't know if that was appropriate.