### PR TITLE
Making import normc_initializer model.py in rllib/example compatible with latest ray[rllib]

### DIFF
--- a/smac/examples/rllib/model.py
+++ b/smac/examples/rllib/model.py
@@ -6,7 +6,7 @@ import tensorflow as tf
 import tensorflow.contrib.slim as slim
 
 from ray.rllib.models import Model
-from ray.rllib.models.misc import normc_initializer
+from ray.rllib.models.tf.misc import normc_initializer
 
 
 class MaskedActionsModel(Model):


### PR DESCRIPTION
Making import normc_initializer model.py in rllib/example compatible with latest ray[rllib], otherwise, it will report a error informing `misc` not found in `ray.rllib.models`.

Ray: 0.8.2

since it uses TF.slim, import the `normc_initializer` from `tf.misc`

`from ray.rllib.models.tf.misc import normc_initializer`