### PR TITLE
contrib has been discarded in new tf 1.x versions and tf 2.x

### DIFF
--- a/smac/examples/rllib/env.py
+++ b/smac/examples/rllib/env.py
@@ -2,6 +2,10 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import random
+
+import numpy as np
+
 from gym.spaces import Discrete, Box, Dict
 
 from ray import rllib

--- a/smac/examples/rllib/env.py
+++ b/smac/examples/rllib/env.py
@@ -94,3 +94,7 @@ class RLlibStarCraft2Env(rllib.MultiAgentEnv):
 
         self._ready_agents = list(range(len(obs_list)))
         return return_obs, rews, dones, infos
+
+    def close(self):
+        """Close the environment"""
+        self._env.close()

--- a/smac/examples/rllib/env.py
+++ b/smac/examples/rllib/env.py
@@ -98,3 +98,7 @@ class RLlibStarCraft2Env(rllib.MultiAgentEnv):
     def close(self):
         """Close the environment"""
         self._env.close()
+
+    def seed(self, seed):
+        random.seed(seed)
+        np.random.seed(seed)

--- a/smac/examples/rllib/env.py
+++ b/smac/examples/rllib/env.py
@@ -48,7 +48,7 @@ class RLlibStarCraft2Env(rllib.MultiAgentEnv):
         return_obs = {}
         for i, obs in enumerate(obs_list):
             return_obs[i] = {
-                "action_mask": self._env.get_avail_agent_actions(i),
+                "action_mask": np.array(self._env.get_avail_agent_actions(i)),
                 "obs": obs,
             }
 

--- a/smac/examples/rllib/model.py
+++ b/smac/examples/rllib/model.py
@@ -3,7 +3,6 @@ from __future__ import division
 from __future__ import print_function
 
 import tensorflow as tf
-import tensorflow.contrib.slim as slim
 
 from ray.rllib.models import Model
 from ray.rllib.models.tf.misc import normc_initializer
@@ -27,18 +26,18 @@ class MaskedActionsModel(Model):
         hiddens = options.get("fcnet_hiddens")
         for i, size in enumerate(hiddens):
             label = "fc{}".format(i)
-            last_layer = slim.fully_connected(
+            last_layer = tf.layers.dense(
                 last_layer,
                 size,
-                weights_initializer=normc_initializer(1.0),
-                activation_fn=tf.nn.tanh,
-                scope=label)
-        action_logits = slim.fully_connected(
+                kernel_initializer=normc_initializer(1.0),
+                activation=tf.nn.tanh,
+                name=label)
+        action_logits = tf.layers.dense(
             last_layer,
             num_outputs,
-            weights_initializer=normc_initializer(0.01),
-            activation_fn=None,
-            scope="fc_out")
+            kernel_initializer=normc_initializer(0.01),
+            activation=None,
+            name="fc_out")
 
         # Mask out invalid actions (use tf.float32.min for stability)
         inf_mask = tf.maximum(tf.log(action_mask), tf.float32.min)


### PR DESCRIPTION
Make the code compatible with new tf 1.x version since the `contrib` has been discarded in new tf 1.x version and tf.compat.v1 in tf 2.x