### PR TITLE
Prevent SC2 from consuming GPU memory

### DIFF
--- a/smac/env/starcraft2/starcraft2.py
+++ b/smac/env/starcraft2/starcraft2.py
@@ -294,7 +294,7 @@ class StarCraft2Env(MultiAgentEnv):
 
         # Setting up the interface
         interface_options = sc_pb.InterfaceOptions(raw=True, score=False)
-        self._sc2_proc = self._run_config.start(window_size=self.window_size)
+        self._sc2_proc = self._run_config.start(window_size=self.window_size, want_rgb=False)
         self._controller = self._sc2_proc.controller
 
         # Request to create the game


### PR DESCRIPTION
Basically, it solves this problem https://github.com/deepmind/pysc2/issues/235 by telling SC2 that no rendering will be done, and so the SC2 process will not consume GPU memory. 

This is a screenshot of `nvidia-smi` in a computer before I applied this patch:

![image](https://user-images.githubusercontent.com/2209364/87878711-4cef3080-c9bc-11ea-8371-b0e749bd550e.png)

Notice all the SC2_x64 processes. The image below is after I applied the patch:

![image](https://user-images.githubusercontent.com/2209364/87878705-3a74f700-c9bc-11ea-9982-afe62d1461d5.png)