### PR TITLE
Fix PZ wrapper active agents calculation

### DIFF
--- a/smac/env/pettingzoo/StarCraft2PZEnv.py
+++ b/smac/env/pettingzoo/StarCraft2PZEnv.py
@@ -161,7 +161,7 @@ class smac_parallel_env(ParallelEnv):
 
     def step(self, all_actions):
         action_list = [0] * self.env.n_agents
-        for agent in self.possible_agents:
+        for agent in self.agents:
             agent_id = self.get_agent_smac_id(agent)
             if agent in all_actions:
                 if all_actions[agent] is None:

--- a/smac/env/pettingzoo/StarCraft2PZEnv.py
+++ b/smac/env/pettingzoo/StarCraft2PZEnv.py
@@ -161,9 +161,6 @@ class smac_parallel_env(ParallelEnv):
 
     def step(self, all_actions):
         action_list = [0] * self.env.n_agents
-        self.agents = [
-            agent for agent in self.agents if not self.all_dones[agent]
-        ]
         for agent in self.possible_agents:
             agent_id = self.get_agent_smac_id(agent)
             if agent in all_actions:
@@ -177,13 +174,13 @@ class smac_parallel_env(ParallelEnv):
 
         all_infos = {agent: {} for agent in self.agents}
         # all_infos.update(smac_info)
-        all_dones = self._all_dones(done)
+        self.all_dones = self._all_dones(done)
+        self.agents = [
+            agent for agent in self.agents if not self.all_dones[agent]
+        ]
         all_rewards = self._all_rewards(self._reward)
         all_observes = self._observe_all()
-
-        self.all_dones = all_dones
-
-        return all_observes, all_rewards, all_dones, all_infos
+        return all_observes, all_rewards, self.all_dones, all_infos
 
     def __del__(self):
         self.env.close()


### PR DESCRIPTION
PettingZoo uses `self.agents` to keep track of the active agents in the environment. In the Smac wrapper, `self.agents` is updated before `self.env.step`, meaning that `self.agents` is always a step behind. This results in  `all_observes` including information from dead agents and it makes it difficult/impossible to know when the env is done when using the PZ wrapper (the usual env_done check is seeing if `self.agents` is empty). 

Full discussion - https://github.com/instadeepai/Mava/issues/297. @rodrigodelazcano @benblack769  