### PR TITLE
migrated from gym to gymnasium

### DIFF
--- a/smac/env/pettingzoo/StarCraft2PZEnv.py
+++ b/smac/env/pettingzoo/StarCraft2PZEnv.py
@@ -62,6 +62,12 @@ class smac_parallel_env(ParallelEnv):
         }
         self._reward = 0
 
+    def observation_space(self, agent):
+        return self.observation_spaces[agent]
+
+    def action_space(self, agent):
+        return self.action_spaces[agent]
+
     def _init_agents(self):
         last_type = ""
         agents = []

--- a/smac/env/pettingzoo/StarCraft2PZEnv.py
+++ b/smac/env/pettingzoo/StarCraft2PZEnv.py
@@ -1,7 +1,7 @@
 from smac.env import StarCraft2Env
-from gym.utils import EzPickle
-from gym.utils import seeding
-from gym import spaces
+from gymnasium.utils import EzPickle
+from gymnasium.utils import seeding
+from gymnasium import spaces
 from pettingzoo.utils.env import ParallelEnv
 from pettingzoo.utils.conversions import (
     parallel_to_aec as from_parallel_wrapper,


### PR DESCRIPTION
While using the smac environment with pettingzoo/supersuit wrappers I noticed some incompatibility as the wrappers used gymnasium for type checking and observation/action spaces are defined with gym