### PR TITLE
Add `state` API for PettingZoo env

### DIFF
--- a/smac/env/pettingzoo/StarCraft2PZEnv.py
+++ b/smac/env/pettingzoo/StarCraft2PZEnv.py
@@ -60,6 +60,8 @@ class smac_parallel_env(ParallelEnv):
             )
             for name in self.agents
         }
+        state_size = env.get_state_size()
+        self.state_space = spaces.Box(low=-1, high=1, shape=(state_size,), dtype="float32")
         self._reward = 0
 
     def observation_space(self, agent):
@@ -196,6 +198,9 @@ class smac_parallel_env(ParallelEnv):
         self.agents = [agent for agent in self.agents if not all_truncs[agent]]
 
         return all_observes, all_rewards, all_terms, all_truncs, all_infos
+    
+    def state(self):
+        return self.env.get_state()
 
     def __del__(self):
         self.env.close()


### PR DESCRIPTION
Current PettingZoo implementation lacks the `state` method, which is [a standard PettingZoo API](https://pettingzoo.farama.org/api/parallel/#pettingzoo.utils.env.ParallelEnv.state). Adding this API will help implementations of centralized training methods like QMIX. 

Made two modifications:
- Add the `state` method following PettingZoo API.
- Add `state_space` variable. It can help get the dimension of states. Although it is not a necessary API for PettingZoo, many PZ environments support `state_space` like [MPE](https://github.com/Farama-Foundation/PettingZoo/blob/bbf00ccacc6dea3a1f746f885b8f871c2890bfe0/pettingzoo/mpe/_mpe_utils/simple_env.py#L112-L117).