### PR TITLE
Set `max_cycles` to PettingZoo env properly

### DIFF
--- a/smac/env/pettingzoo/StarCraft2PZEnv.py
+++ b/smac/env/pettingzoo/StarCraft2PZEnv.py
@@ -1,4 +1,5 @@
 from smac.env import StarCraft2Env
+from smac.env.starcraft2.maps import get_map_params
 from gymnasium.utils import EzPickle
 from gymnasium.utils import seeding
 from gymnasium import spaces
@@ -13,6 +14,8 @@ max_cycles_default = 1000
 
 
 def parallel_env(max_cycles=max_cycles_default, **smac_args):
+    map_name = smac_args.get("map_name", "8m")
+    max_cycles = get_map_params(map_name)["limit"]
     return _parallel_env(max_cycles, **smac_args)
 
 

--- a/smac/env/pettingzoo/StarCraft2PZEnv.py
+++ b/smac/env/pettingzoo/StarCraft2PZEnv.py
@@ -10,16 +10,15 @@ from pettingzoo.utils.conversions import (
 from pettingzoo.utils import wrappers
 import numpy as np
 
-max_cycles_default = 1000
 
-
-def parallel_env(max_cycles=max_cycles_default, **smac_args):
-    map_name = smac_args.get("map_name", "8m")
-    max_cycles = get_map_params(map_name)["limit"]
+def parallel_env(max_cycles=None, **smac_args):
+    if max_cycles is None:
+        map_name = smac_args.get("map_name", "8m")
+        max_cycles = get_map_params(map_name)["limit"]
     return _parallel_env(max_cycles, **smac_args)
 
 
-def raw_env(max_cycles=max_cycles_default, **smac_args):
+def raw_env(max_cycles=None, **smac_args):
     return from_parallel_wrapper(parallel_env(max_cycles, **smac_args))
 
 


### PR DESCRIPTION
The `max_cycles` value in PettingZoo env will be used to provide `truncated` signals for `env.step` return. However, this property requires to be manually set when creating the env. This PR proposes to set `max_cycles` according to SMAC's `get_map_params` function to acquire the correct value of maximal episode steps.