### PR TITLE
Update protobuf version and fix compatibility with latest numpy versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     ],
     extras_require=extras_deps,
     install_requires=[
-        "protobuf==3.19.5",
+        "protobuf<3.21",
         "pysc2>=3.0.0",
         "s2clientprotocol>=4.10.1.75800.0",
         "absl-py>=0.1.0",

--- a/smac/env/starcraft2/starcraft2.py
+++ b/smac/env/starcraft2/starcraft2.py
@@ -374,7 +374,7 @@ class StarCraft2Env(MultiAgentEnv):
                 np.flip(
                     np.transpose(
                         np.array(
-                            list(map_info.pathing_grid.data), dtype=np.bool
+                            list(map_info.pathing_grid.data), dtype=bool
                         ).reshape(self.map_x, self.map_y)
                     ),
                     axis=1,
@@ -1346,7 +1346,7 @@ class StarCraft2Env(MultiAgentEnv):
         """
         arr = np.zeros(
             (self.n_agents, self.n_agents + self.n_enemies),
-            dtype=np.bool,
+            dtype=bool,
         )
 
         for agent_id in range(self.n_agents):


### PR DESCRIPTION
Usage of `np.bool`, `np.int` and `np.float` is deprecated in recent numpy versions and throws an error. Here I replace `np.bool` with `bool`, as recommended by the numpy documentation.
Reference: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

Moreover, the protobuf version specified is incompatible with recent Ray versions (and therefore rllib). Thus, I bumped the protobuf version to the same as the one used in SMACv2.

These changes should not alter the code behavior.

